### PR TITLE
pull all circom-related functionality from binaries into library

### DIFF
--- a/phase2/src/bin/export_keys.rs
+++ b/phase2/src/bin/export_keys.rs
@@ -1,64 +1,11 @@
-extern crate bellman_ce;
-extern crate rand;
 extern crate phase2;
 extern crate exitcode;
-extern crate serde;
-extern crate serde_json;
-extern crate num_bigint;
-extern crate num_traits;
-extern crate itertools;
 
-use std::fs;
-use std::fs::OpenOptions;
-use std::iter::repeat;
-use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use phase2::parameters::MPCParameters;
-use phase2::utils::{
-    p1_to_vec,
-    p2_to_vec,
-    pairing_to_vec,
+use phase2::circom_circuit::{
+    proving_key_json_file,
+    verification_key_json_file,
+    load_params_file
 };
-use bellman_ce::pairing::{
-    Engine,
-    bn256::{
-        Bn256,
-    }
-};
-
-#[derive(Serialize, Deserialize)]
-struct ProvingKeyJson {
-    #[serde(rename = "A")]
-    pub a: Vec<Vec<String>>,
-    #[serde(rename = "B1")]
-    pub b1: Vec<Vec<String>>,
-    #[serde(rename = "B2")]
-    pub b2: Vec<Vec<Vec<String>>>,
-    #[serde(rename = "C")]
-    pub c: Vec<Option<Vec<String>>>,
-    pub vk_alfa_1: Vec<String>,
-    pub vk_beta_1: Vec<String>,
-    pub vk_delta_1: Vec<String>,
-    pub vk_beta_2: Vec<Vec<String>>,
-    pub vk_delta_2: Vec<Vec<String>>,
-    #[serde(rename = "hExps")]
-    pub h: Vec<Vec<String>>,
-    // Todo: add json fields: nPublic, nVars, polsA, polsB, polsC, protocol: groth
-}
-
-#[derive(Serialize, Deserialize)]
-struct VerifyingKeyJson {
-    #[serde(rename = "IC")]
-    pub ic: Vec<Vec<String>>,
-    pub vk_alfa_1: Vec<String>,
-    pub vk_beta_2: Vec<Vec<String>>,
-    pub vk_gamma_2: Vec<Vec<String>>,
-    pub vk_delta_2: Vec<Vec<String>>,
-    pub vk_alfabeta_12: Vec<Vec<Vec<String>>>,
-    pub protocol: String,
-    #[serde(rename = "nPublic")]
-    pub inputs_count: usize,
-}
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -69,46 +16,9 @@ fn main() {
     let params_filename = &args[1];
     let vk_filename = &args[2];
     let pk_filename = &args[3];
-
-    let disallow_points_at_infinity = false;
-
     println!("Exporting {}...", params_filename);
-
-    let reader = OpenOptions::new()
-                            .read(true)
-                            .open(params_filename)
-                            .expect("unable to open.");
-    let params = MPCParameters::read(reader, disallow_points_at_infinity, true).expect("unable to read params");
-    let params = params.get_params();
-
-    let proving_key = ProvingKeyJson {
-        a: params.a.iter().map(|e| p1_to_vec(e)).collect_vec(),
-        b1: params.b_g1.iter().map(|e| p1_to_vec(e)).collect_vec(),
-        b2: params.b_g2.iter().map(|e| p2_to_vec(e)).collect_vec(),
-        c: repeat(None).take(params.vk.ic.len()).chain(params.l.iter().map(|e| Some(p1_to_vec(e)))).collect_vec(),
-        vk_alfa_1: p1_to_vec(&params.vk.alpha_g1),
-        vk_beta_1: p1_to_vec(&params.vk.beta_g1),
-        vk_delta_1: p1_to_vec(&params.vk.delta_g1),
-        vk_beta_2: p2_to_vec(&params.vk.beta_g2),
-        vk_delta_2: p2_to_vec(&params.vk.delta_g2),
-        h: params.h.iter().map(|e| p1_to_vec(e)).collect_vec(),
-    };
-
-    let verification_key = VerifyingKeyJson {
-        ic: params.vk.ic.iter().map(|e| p1_to_vec(e)).collect_vec(),
-        vk_alfa_1: p1_to_vec(&params.vk.alpha_g1),
-        vk_beta_2: p2_to_vec(&params.vk.beta_g2),
-        vk_gamma_2: p2_to_vec(&params.vk.gamma_g2),
-        vk_delta_2: p2_to_vec(&params.vk.delta_g2),
-        vk_alfabeta_12: pairing_to_vec(&Bn256::pairing(params.vk.alpha_g1, params.vk.beta_g2)),
-        inputs_count: params.vk.ic.len() - 1,
-        protocol: String::from("groth"),
-    };
-
-    let pk_json = serde_json::to_string(&proving_key).unwrap();
-    let vk_json = serde_json::to_string(&verification_key).unwrap();
-    fs::write(pk_filename, pk_json.as_bytes()).unwrap();
-    fs::write(vk_filename, vk_json.as_bytes()).unwrap();
-
+    let params = load_params_file(params_filename);
+    proving_key_json_file(&params, pk_filename).unwrap();
+    verification_key_json_file(&params, vk_filename).unwrap();
     println!("Created {} and {}.", pk_filename, vk_filename);
 }

--- a/phase2/src/bin/export_keys.rs
+++ b/phase2/src/bin/export_keys.rs
@@ -43,6 +43,7 @@ struct ProvingKeyJson {
     pub vk_delta_2: Vec<Vec<String>>,
     #[serde(rename = "hExps")]
     pub h: Vec<Vec<String>>,
+    // Todo: add json fields: nPublic, nVars, polsA, polsB, polsC, protocol: groth
 }
 
 #[derive(Serialize, Deserialize)]
@@ -54,6 +55,9 @@ struct VerifyingKeyJson {
     pub vk_gamma_2: Vec<Vec<String>>,
     pub vk_delta_2: Vec<Vec<String>>,
     pub vk_alfabeta_12: Vec<Vec<Vec<String>>>,
+    pub protocol: String,
+    #[serde(rename = "nPublic")]
+    pub inputs_count: usize,
 }
 
 fn main() {
@@ -97,6 +101,8 @@ fn main() {
         vk_gamma_2: p2_to_vec(&params.vk.gamma_g2),
         vk_delta_2: p2_to_vec(&params.vk.delta_g2),
         vk_alfabeta_12: pairing_to_vec(&Bn256::pairing(params.vk.alpha_g1, params.vk.beta_g2)),
+        inputs_count: params.vk.ic.len() - 1,
+        protocol: String::from("groth"),
     };
 
     let pk_json = serde_json::to_string(&proving_key).unwrap();

--- a/phase2/src/bin/generate_verifier.rs
+++ b/phase2/src/bin/generate_verifier.rs
@@ -1,26 +1,9 @@
-#![allow(unused_imports)]
-
 extern crate phase2;
-extern crate bellman_ce;
-extern crate num_bigint;
-extern crate num_traits;
 extern crate exitcode;
-extern crate serde;
 
-use std::fmt;
-use std::fs;
-use std::fs::OpenOptions;
-use num_bigint::BigUint;
-use num_traits::Num;
-use phase2::utils::repr_to_big;
-use phase2::parameters::MPCParameters;
-use bellman_ce::pairing::{
-    Engine,
-    CurveAffine,
-    ff::PrimeField,
-    bn256::{
-        Bn256,
-    }
+use phase2::circom_circuit::{
+    load_params_file,
+    create_verifier_sol_file
 };
 
 fn main() {
@@ -31,48 +14,7 @@ fn main() {
     }
     let params_filename = &args[1];
     let verifier_filename = &args[2];
-
-    let should_filter_points_at_infinity = false;
-    let bytes = include_bytes!("../verifier_groth.sol");
-    let template = String::from_utf8_lossy(bytes);
-
-    let reader = OpenOptions::new()
-        .read(true)
-        .open(params_filename)
-        .expect("unable to open.");
-
-    let params = MPCParameters::read(reader, should_filter_points_at_infinity, true).expect("unable to read params");
-    let vk = &params.get_params().vk;
-
-    let p1_to_str = |p: &<Bn256 as Engine>::G1Affine| {
-        let x = repr_to_big(p.get_x().into_repr());
-        let y = repr_to_big(p.get_y().into_repr());
-        return format!("{}, {}", x, y)
-    };
-    let p2_to_str = |p: &<Bn256 as Engine>::G2Affine| {
-        let x = p.get_x();
-        let y = p.get_y();
-        let x_c0 = repr_to_big(x.c0.into_repr());
-        let x_c1 = repr_to_big(x.c1.into_repr());
-        let y_c0 = repr_to_big(y.c0.into_repr());
-        let y_c1 = repr_to_big(y.c1.into_repr());
-        format!("[{}, {}], [{}, {}]", x_c0, x_c1, y_c0, y_c1)
-    };
-
-    let template = template.replace("<%vk_alfa1%>", &*p1_to_str(&vk.alpha_g1));
-    let template = template.replace("<%vk_beta2%>", &*p2_to_str(&vk.beta_g2));
-    let template = template.replace("<%vk_gamma2%>", &*p2_to_str(&vk.gamma_g2));
-    let template = template.replace("<%vk_delta2%>", &*p2_to_str(&vk.delta_g2));
-
-    let template = template.replace("<%vk_ic_length%>", &*vk.ic.len().to_string());
-    let template = template.replace("<%vk_input_length%>", &*(vk.ic.len() - 1).to_string());
-
-    let mut vi = String::from("");
-    for i in 0..vk.ic.len() {
-        vi = format!("{}{}vk.IC[{}] = Pairing.G1Point({});\n", vi, if vi.len() == 0 { "" } else { "        " }, i, &*p1_to_str(&vk.ic[i]));
-    }
-    let template = template.replace("<%vk_ic_pts%>", &*vi);
-
-    fs::write(verifier_filename, template.as_bytes()).unwrap();
+    let params = load_params_file(params_filename);
+    create_verifier_sol_file(&params, verifier_filename).unwrap();
     println!("Created {}", verifier_filename);
 }

--- a/phase2/src/bin/new.rs
+++ b/phase2/src/bin/new.rs
@@ -4,7 +4,7 @@ extern crate exitcode;
 
 use std::fs::File;
 use phase2::parameters::MPCParameters;
-use phase2::circom_circuit::CircomCircuit;
+use phase2::circom_circuit::circuit_from_json_file;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -20,7 +20,7 @@ fn main() {
     // Import the circuit and create the initial parameters using phase 1
     println!("Creating initial parameters for {}...", circuit_filename);
     let params = {
-        let c = CircomCircuit::from_json_file(&circuit_filename);
+        let c = circuit_from_json_file(&circuit_filename);
         MPCParameters::new(c, should_filter_points_at_infinity).unwrap()
     };
 

--- a/phase2/src/bin/prove.rs
+++ b/phase2/src/bin/prove.rs
@@ -9,12 +9,13 @@ extern crate itertools;
 use std::fs;
 use bellman_ce::pairing::bn256::Bn256;
 use phase2::circom_circuit::{
-    CircomCircuit,
     load_params_file,
     prove,
     verify,
     create_rng,
-    proof_to_json_file
+    proof_to_json_file,
+    circuit_from_json_file,
+    witness_from_json_file
 };
 
 fn main() {
@@ -31,8 +32,8 @@ fn main() {
 
     let rng = create_rng();
     let params = load_params_file(params_filename);
-    let mut circuit = CircomCircuit::from_json_file(circuit_filename);
-    circuit.witness =  Some(CircomCircuit::<Bn256>::witness_from_json_file(witness_filename));
+    let mut circuit = circuit_from_json_file(circuit_filename);
+    circuit.witness =  Some(witness_from_json_file::<Bn256>(witness_filename));
 
     println!("Proving...");
     let proof = prove(circuit.clone(), &params, rng).unwrap();

--- a/phase2/src/bin/prove.rs
+++ b/phase2/src/bin/prove.rs
@@ -7,27 +7,15 @@ extern crate num_traits;
 extern crate itertools;
 
 use std::fs;
-use std::fs::OpenOptions;
-use serde::{Deserialize, Serialize};
-use itertools::Itertools;
-use phase2::parameters::MPCParameters;
-use phase2::circom_circuit::CircomCircuit;
-use phase2::utils::{
-    repr_to_big,
-    p1_to_vec,
-    p2_to_vec,
+use bellman_ce::pairing::bn256::Bn256;
+use phase2::circom_circuit::{
+    CircomCircuit,
+    load_params_file,
+    prove,
+    verify,
+    create_rng,
+    proof_to_json_file
 };
-use bellman_ce::groth16::{prepare_verifying_key, create_random_proof, verify_proof};
-use bellman_ce::pairing::ff::PrimeField;
-
-#[derive(Serialize, Deserialize)]
-struct ProofJson {
-    pub protocol: String,
-    pub pi_a: Vec<String>,
-    pub pi_b: Vec<Vec<String>>,
-    pub pi_c: Vec<String>,
-}
-
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -41,48 +29,21 @@ fn main() {
     let proof_filename = &args[4];
     let public_filename = &args[5];
 
-    let should_filter_points_at_infinity = false;
-    let rng = &mut rand::XorShiftRng::new_unseeded(); // TODO: change this unsafe unseeded random (!)
-
-    let mut c = CircomCircuit::from_json_file(circuit_filename);
-    c.load_witness_json_file(witness_filename);
-    let input = c.inputs.to_vec();
-
-    let reader = OpenOptions::new()
-        .read(true)
-        .open(params_filename)
-        .expect("unable to open.");
-
-    let mut params = MPCParameters::read(reader, should_filter_points_at_infinity, true).expect("unable to read params");
-
-    params.filter_params();
-    let params = params.get_params();
+    let rng = create_rng();
+    let params = load_params_file(params_filename);
+    let mut circuit = CircomCircuit::from_json_file(circuit_filename);
+    circuit.witness =  Some(CircomCircuit::<Bn256>::witness_from_json_file(witness_filename));
 
     println!("Proving...");
-    let proof = create_random_proof(c, &*params, rng).unwrap();
+    let proof = prove(circuit.clone(), &params, rng).unwrap();
 
-    println!("Checking proof");
-    let pvk = prepare_verifying_key(&params.vk);
-    let result = verify_proof(
-        &pvk,
-        &proof,
-        &input[1..]
-    ).unwrap();
-    assert!(result, "Proof is correct");
+    println!("Verifying proof");
+    let correct = verify(&circuit, &params, &proof).unwrap();
+    assert!(correct, "Proof is correct");
 
-    let proof = ProofJson {
-        protocol: "groth".to_string(),
-        pi_a: p1_to_vec(&proof.a),
-        pi_b: p2_to_vec(&proof.b),
-        pi_c: p1_to_vec(&proof.c),
-    };
-
-    let proof_json = serde_json::to_string(&proof).unwrap();
-    fs::write(proof_filename, proof_json.as_bytes()).unwrap();
-
-    let public_inputs = input[1..].iter().map(|x| repr_to_big(x.into_repr())).collect_vec();
-    let public_json = serde_json::to_string(&public_inputs).unwrap();
-    fs::write(public_filename, public_json.as_bytes()).unwrap();
+    println!("Saving {} and {}", proof_filename, public_filename);
+    proof_to_json_file(&proof, proof_filename).unwrap();
+    fs::write(public_filename, circuit.get_public_inputs_json().as_bytes()).unwrap();
 
     println!("Done!")
 }

--- a/phase2/src/bin/verify_contribution.rs
+++ b/phase2/src/bin/verify_contribution.rs
@@ -4,7 +4,7 @@ extern crate exitcode;
 use std::fs::OpenOptions;
 
 use phase2::parameters::*;
-use phase2::circom_circuit::CircomCircuit;
+use phase2::circom_circuit::circuit_from_json_file;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -34,7 +34,7 @@ fn main() {
     let contribution = verify_contribution(&old_params, &new_params).expect("should verify");
 
     let should_filter_points_at_infinity = false;
-    let verification_result = new_params.verify(CircomCircuit::from_json_file(&circuit_filename), should_filter_points_at_infinity).unwrap();
+    let verification_result = new_params.verify(circuit_from_json_file(&circuit_filename), should_filter_points_at_infinity).unwrap();
     assert!(contains_contribution(&verification_result, &contribution));
     println!("Contribution {} verified.", new_params_filename);
 }

--- a/phase2/src/circom_circuit.rs
+++ b/phase2/src/circom_circuit.rs
@@ -256,7 +256,7 @@ pub fn create_verifier_sol(params: &Parameters<Bn256>) -> String {
         let x_c1 = repr_to_big(x.c1.into_repr());
         let y_c0 = repr_to_big(y.c0.into_repr());
         let y_c1 = repr_to_big(y.c1.into_repr());
-        format!("[{}, {}], [{}, {}]", x_c0, x_c1, y_c0, y_c1)
+        format!("[{}, {}], [{}, {}]", x_c1, x_c0, y_c1, y_c0)
     };
 
     let template = template.replace("<%vk_alfa1%>", &*p1_to_str(&params.vk.alpha_g1));

--- a/phase2/src/parameters.rs
+++ b/phase2/src/parameters.rs
@@ -401,14 +401,6 @@ impl MPCParameters {
         &self.params
     }
 
-    pub fn filter_params(&mut self) {
-        self.params.vk.ic = self.params.vk.ic.clone().into_iter().filter(|x| !x.is_zero()).collect::<Vec<_>>();
-        self.params.h = Arc::new((*self.params.h).clone().into_iter().filter(|x| !x.is_zero()).collect::<Vec<_>>());
-        self.params.a = Arc::new((*self.params.a).clone().into_iter().filter(|x| !x.is_zero()).collect::<Vec<_>>());
-        self.params.b_g1 = Arc::new((*self.params.b_g1).clone().into_iter().filter(|x| !x.is_zero()).collect::<Vec<_>>());
-        self.params.b_g2 = Arc::new((*self.params.b_g2).clone().into_iter().filter(|x| !x.is_zero()).collect::<Vec<_>>());
-    }
-
     /// Contributes some randomness to the parameters. Only one
     /// contributor needs to be honest for the parameters to be
     /// secure.

--- a/phase2/src/utils.rs
+++ b/phase2/src/utils.rs
@@ -16,9 +16,7 @@ use bellman_ce::pairing::{
     CurveAffine,
     CurveProjective,
     Wnaf,
-    Engine,
     bn256::{
-        Bn256,
         G2,
         G1Affine,
         G2Affine,

--- a/phase2/src/verifier_groth.sol
+++ b/phase2/src/verifier_groth.sol
@@ -187,14 +187,13 @@ contract Verifier {
 
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+        vk_x = Pairing.plus(vk_x, vk.IC[0]);
 
         // Make sure that every input is less than the snark scalar field
         for (uint256 i = 0; i < input.length; i++) {
             require(input[i] < SNARK_SCALAR_FIELD, "verifier-gte-snark-scalar-field");
             vk_x = Pairing.plus(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         }
-
-        vk_x = Pairing.plus(vk_x, vk.IC[0]);
 
         return Pairing.pairing(
             Pairing.negate(_proof.A),

--- a/phase2/src/verifier_groth.sol
+++ b/phase2/src/verifier_groth.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.0;
 
 library Pairing {
-
     uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
 
     struct G1Point {
@@ -35,10 +34,9 @@ library Pairing {
     }
 
     /*
-     * @return The negation of p, i.e. p.plus(p.negate()) should be zero. 
+     * @return The negation of p, i.e. p.plus(p.negate()) should be zero.
      */
     function negate(G1Point memory p) internal pure returns (G1Point memory) {
-
         // The prime q in the base field F_q for G1
         if (p.X == 0 && p.Y == 0) {
             return G1Point(0, 0);
@@ -54,7 +52,6 @@ library Pairing {
         G1Point memory p1,
         G1Point memory p2
     ) internal view returns (G1Point memory r) {
-
         uint256[4] memory input;
         input[0] = p1.X;
         input[1] = p1.Y;
@@ -69,7 +66,7 @@ library Pairing {
             switch success case 0 { invalid() }
         }
 
-        require(success,"pairing-add-failed");
+        require(success, "pairing-add-failed");
     }
 
     /*
@@ -78,7 +75,6 @@ library Pairing {
      *         points p.
      */
     function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
-
         uint256[3] memory input;
         input[0] = p.X;
         input[1] = p.Y;
@@ -90,7 +86,7 @@ library Pairing {
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
-        require (success,"pairing-mul-failed");
+        require(success, "pairing-mul-failed");
     }
 
     /* @return The result of computing the pairing check
@@ -108,7 +104,6 @@ library Pairing {
         G1Point memory d1,
         G2Point memory d2
     ) internal view returns (bool) {
-
         G1Point[4] memory p1 = [a1, b1, c1, d1];
         G2Point[4] memory p2 = [a2, b2, c2, d2];
 
@@ -142,11 +137,9 @@ library Pairing {
 }
 
 contract Verifier {
-
-    using Pairing for *;
-
     uint256 constant SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
     uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+    using Pairing for *;
 
     struct VerifyingKey {
         Pairing.G1Point alfa1;
@@ -169,7 +162,7 @@ contract Verifier {
         vk.delta2 = Pairing.G2Point(<%vk_delta2%>);
         <%vk_ic_pts%>
     }
-    
+
     /*
      * @returns Whether the proof is valid given the hardcoded verifying key
      *          above and the public inputs
@@ -178,7 +171,6 @@ contract Verifier {
         bytes memory proof,
         uint256[<%vk_input_length%>] memory input
     ) public view returns (bool r) {
-
         uint256[8] memory p = abi.decode(proof, (uint256[8]));
 
         // Make sure that each element in the proof is less than the prime q
@@ -198,7 +190,7 @@ contract Verifier {
 
         // Make sure that every input is less than the snark scalar field
         for (uint256 i = 0; i < input.length; i++) {
-            require(input[i] < SNARK_SCALAR_FIELD,"verifier-gte-snark-scalar-field");
+            require(input[i] < SNARK_SCALAR_FIELD, "verifier-gte-snark-scalar-field");
             vk_x = Pairing.plus(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         }
 

--- a/phase2/src/verifier_groth.sol
+++ b/phase2/src/verifier_groth.sol
@@ -9,7 +9,7 @@
 //      fixed linter warnings
 //      added require error messages
 //
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 library Pairing {
     struct G1Point {
         uint X;
@@ -52,7 +52,7 @@ library Pairing {
             return G1Point(0, 0);
         return G1Point(p.X, q - (p.Y % q));
     }
-    /// @return the sum of two points of G1
+    /// @return r the sum of two points of G1
     function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
         uint[4] memory input;
         input[0] = p1.X;
@@ -62,13 +62,13 @@ library Pairing {
         bool success;
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas, 2000), 6, input, 0xc0, r, 0x60)
+            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
         require(success,"pairing-add-failed");
     }
-    /// @return the product of a point on G1 and a scalar, i.e.
+    /// @return r the product of a point on G1 and a scalar, i.e.
     /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
     function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
         uint[3] memory input;
@@ -78,7 +78,7 @@ library Pairing {
         bool success;
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas, 2000), 7, input, 0x80, r, 0x60)
+            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
@@ -106,7 +106,7 @@ library Pairing {
         bool success;
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas, 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
@@ -181,43 +181,45 @@ contract Verifier {
         vk.IC = new Pairing.G1Point[](<%vk_ic_length%>);
         <%vk_ic_pts%>
     }
-    function verify(uint[] memory input, Proof memory proof) internal view returns (uint) {
+    function verify(Proof memory proof, uint[<%vk_input_length%>] memory input) internal view returns (bool) {
         uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
         VerifyingKey memory vk = verifyingKey();
-        require(input.length + 1 == vk.IC.length,"verifier-bad-input");
+        require(input.length + 1 == vk.IC.length, "verifier-bad-input");
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+        vk_x = Pairing.addition(vk_x, vk.IC[0]);
         for (uint i = 0; i < input.length; i++) {
-            require(input[i] < snark_scalar_field,"verifier-gte-snark-scalar-field");
+            require(input[i] < snark_scalar_field, "verifier-gte-snark-scalar-field");
             vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         }
-        vk_x = Pairing.addition(vk_x, vk.IC[0]);
-        if (!Pairing.pairingProd4(
+        return Pairing.pairingProd4(
             Pairing.negate(proof.A), proof.B,
             vk.alfa1, vk.beta2,
             vk_x, vk.gamma2,
             proof.C, vk.delta2
-        )) return 1;
-        return 0;
+        );
     }
     function verifyProof(
             uint[2] memory a,
             uint[2][2] memory b,
             uint[2] memory c,
             uint[<%vk_input_length%>] memory input
-        ) public view returns (bool r) {
-        Proof memory proof;
-        proof.A = Pairing.G1Point(a[0], a[1]);
-        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
-        proof.C = Pairing.G1Point(c[0], c[1]);
-        return verify(input, proof);
+        ) public view returns (bool) {
+        Proof memory _proof;
+        _proof.A = Pairing.G1Point(a[0], a[1]);
+        _proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+        _proof.C = Pairing.G1Point(c[0], c[1]);
+        return verify(_proof, input);
     }
-    function verifyProof(bytes memory proof, uint[<%vk_input_length%>] memory inputs) public view returns (bool r) {
+    function verifyProof(
+            bytes memory proof,
+            uint[<%vk_input_length%>] memory input
+        ) public view returns (bool) {
         uint[8] memory p = abi.decode(proof, (uint[8]));
-        Proof memory proof;
-        proof.A = Pairing.G1Point(p[0], p[1]);
-        proof.B = Pairing.G2Point([p[2], p[3]], [p[4], p[5]]);
-        proof.C = Pairing.G1Point(p[6], c[7]);
-        return verify(inputs, proof) == 0;
+        Proof memory _proof;
+        _proof.A = Pairing.G1Point(p[0], p[1]);
+        _proof.B = Pairing.G2Point([p[2], p[3]], [p[4], p[5]]);
+        _proof.C = Pairing.G1Point(p[6], p[7]);
+        return verify(_proof, input);
     }
 }

--- a/phase2/test.sh
+++ b/phase2/test.sh
@@ -26,14 +26,13 @@ cargo run --release --bin verify_contribution circuit.json circom2.params circom
 cargo run --release --bin contribute circom3.params circom4.params askldfjklasdf
 cargo run --release --bin verify_contribution circuit.json circom3.params circom4.params
 
-# generate resulting keys
-cargo run --release --bin export_keys circom4.params vk.json pk.json
 # create dummy keys in circom format
 echo "Generating dummy key files..."
 npx snarkjs setup --protocol groth
+# generate resulting keys
+cargo run --release --bin export_keys circom4.params vk.json pk.json
 # patch dummy keys with actual keys params
 cargo run --release --bin copy_json proving_key.json pk.json transformed_pk.json
-cargo run --release --bin copy_json verification_key.json vk.json transformed_vk.json
 
 # generate solidity verifier
 cargo run --release --bin generate_verifier circom4.params verifier.sol
@@ -41,4 +40,4 @@ cargo run --release --bin generate_verifier circom4.params verifier.sol
 # try to generate and verify proof
 npx snarkjs calculatewitness
 cargo run --release --bin prove circuit.json witness.json circom4.params proof.json public.json
-npx snarkjs verify --vk transformed_vk.json --proof proof.json
+npx snarkjs verify --vk vk.json --proof proof.json


### PR DESCRIPTION
now binaries for proving, generating verifier and keys are minimal wrappers around helper functions in the library