### PR TITLE
Make setup abstract over the curve being used

### DIFF
--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -45,11 +45,11 @@ pub struct BatchedAccumulator<'a, E: Engine> {
     /// Hash chain hash
     pub hash: GenericArray<u8, U64>,
     /// The parameters used for the setup of this accumulator
-    pub parameters: &'a CeremonyParams,
+    pub parameters: &'a CeremonyParams<E>,
 }
 
 impl<'a, E: Engine> BatchedAccumulator<'a, E> {
-    pub fn empty(parameters: &'a CeremonyParams) -> Self {
+    pub fn empty(parameters: &'a CeremonyParams<E>) -> Self {
         Self {
             tau_powers_g1: vec![],
             tau_powers_g2: vec![],
@@ -283,7 +283,7 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         output_is_compressed: UseCompression,
         check_input_for_correctness: CheckForCorrectness,
         check_output_for_correctness: CheckForCorrectness,
-        parameters: &'a CeremonyParams,
+        parameters: &'a CeremonyParams<E>,
     ) -> bool {
         use itertools::MinMaxResult::MinMax;
         assert_eq!(digest.len(), 64);
@@ -543,7 +543,7 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         input_map: &Mmap,
         output_map: &mut MmapMut,
         check_input_for_correctness: CheckForCorrectness,
-        parameters: &'a CeremonyParams,
+        parameters: &'a CeremonyParams<E>,
     ) -> io::Result<()> {
         use itertools::MinMaxResult::MinMax;
 
@@ -620,7 +620,7 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         input_map: &Mmap,
         check_input_for_correctness: CheckForCorrectness,
         compression: UseCompression,
-        parameters: &'a CeremonyParams,
+        parameters: &'a CeremonyParams<E>,
     ) -> io::Result<BatchedAccumulator<'a, E>> {
         use itertools::MinMaxResult::MinMax;
 
@@ -720,7 +720,7 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         &mut self,
         output_map: &mut MmapMut,
         compression: UseCompression,
-        parameters: &CeremonyParams,
+        parameters: &CeremonyParams<E>,
     ) -> io::Result<()> {
         use itertools::MinMaxResult::MinMax;
 
@@ -1122,7 +1122,7 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         compress_the_output: UseCompression,
         check_input_for_correctness: CheckForCorrectness,
         key: &PrivateKey<E>,
-        parameters: &'a CeremonyParams,
+        parameters: &'a CeremonyParams<E>,
     ) -> io::Result<()> {
         /// Exponentiate a large number of points, with an optional coefficient to be applied to the
         /// exponent.
@@ -1294,7 +1294,7 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
     pub fn generate_initial(
         output_map: &mut MmapMut,
         compress_the_output: UseCompression,
-        parameters: &'a CeremonyParams,
+        parameters: &'a CeremonyParams<E>,
     ) -> io::Result<()> {
         use itertools::MinMaxResult::MinMax;
 

--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -2,7 +2,6 @@
 /// and then contributes to entropy in parts as well
 use bellman_ce::pairing::ff::{Field, PrimeField};
 use bellman_ce::pairing::*;
-use blake2::{Blake2b, Digest};
 use log::{error, info};
 
 use generic_array::GenericArray;
@@ -50,19 +49,6 @@ pub struct BatchedAccumulator<'a, E: Engine> {
 }
 
 impl<'a, E: Engine> BatchedAccumulator<'a, E> {
-    /// Calculate the contribution hash from the resulting file. Original powers of tau implementation
-    /// used a specially formed writer to write to the file and calculate a hash on the fly, but memory-constrained
-    /// implementation now writes without a particular order, so plain recalculation at the end
-    /// of the procedure is more efficient
-    pub fn calculate_hash(input_map: &Mmap) -> GenericArray<u8, U64> {
-        let chunk_size = 1 << 30; // read by 1GB from map
-        let mut hasher = Blake2b::default();
-        for chunk in input_map.chunks(chunk_size) {
-            hasher.input(&chunk);
-        }
-        hasher.result()
-    }
-
     pub fn empty(parameters: &'a CeremonyParams) -> Self {
         Self {
             tau_powers_g1: vec![],

--- a/powersoftau/src/bin/beacon_constrained.rs
+++ b/powersoftau/src/bin/beacon_constrained.rs
@@ -1,7 +1,7 @@
 use powersoftau::{
     batched_accumulator::BatchedAccumulator,
     keypair::keypair,
-    parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
+    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
     utils::calculate_hash,
 };
 
@@ -30,7 +30,7 @@ fn main() {
     let circuit_power = args[3].parse().expect("could not parse circuit power");
     let batch_size = args[4].parse().expect("could not parse batch size");
 
-    let parameters = CeremonyParams::new(CurveKind::Bn256, circuit_power, batch_size);
+    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
 
     println!(
         "Will contribute a random beacon to accumulator for 2^{} powers of tau",
@@ -180,7 +180,7 @@ fn main() {
     println!("Computing and writing your contribution, this could take a while...");
 
     // this computes a transformation and writes it
-    BatchedAccumulator::<Bn256>::transform(
+    BatchedAccumulator::transform(
         &readable_map,
         &mut writable_map,
         INPUT_IS_COMPRESSED,

--- a/powersoftau/src/bin/beacon_constrained.rs
+++ b/powersoftau/src/bin/beacon_constrained.rs
@@ -2,6 +2,7 @@ use powersoftau::{
     batched_accumulator::BatchedAccumulator,
     keypair::keypair,
     parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
+    utils::calculate_hash,
 };
 
 use bellman_ce::pairing::bn256::Bn256;
@@ -148,7 +149,7 @@ fn main() {
 
     println!("Calculating previous contribution hash...");
 
-    let current_accumulator_hash = BatchedAccumulator::<Bn256>::calculate_hash(&readable_map);
+    let current_accumulator_hash = calculate_hash(&readable_map);
 
     {
         println!("Contributing on top of the hash:");
@@ -200,7 +201,7 @@ fn main() {
     let output_readonly = writable_map
         .make_read_only()
         .expect("must make a map readonly");
-    let contribution_hash = BatchedAccumulator::<Bn256>::calculate_hash(&output_readonly);
+    let contribution_hash = calculate_hash(&output_readonly);
 
     print!(
         "Done!\n\n\

--- a/powersoftau/src/bin/compute_constrained.rs
+++ b/powersoftau/src/bin/compute_constrained.rs
@@ -1,14 +1,15 @@
-use powersoftau::batched_accumulator::BatchedAccumulator;
-use powersoftau::keypair::keypair;
-use powersoftau::parameters::{CheckForCorrectness, UseCompression};
+use powersoftau::{
+    batched_accumulator::BatchedAccumulator,
+    keypair::keypair,
+    parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
+    utils::calculate_hash,
+};
 
 use bellman_ce::pairing::bn256::Bn256;
 use memmap::*;
 use std::fs::OpenOptions;
 
 use std::io::{Read, Write};
-
-use powersoftau::parameters::{CeremonyParams, CurveKind};
 
 const INPUT_IS_COMPRESSED: UseCompression = UseCompression::No;
 const COMPRESS_THE_OUTPUT: UseCompression = UseCompression::Yes;
@@ -136,7 +137,7 @@ fn main() {
         UseCompression::No == INPUT_IS_COMPRESSED,
         "Hashing the compressed file in not yet defined"
     );
-    let current_accumulator_hash = BatchedAccumulator::<Bn256>::calculate_hash(&readable_map);
+    let current_accumulator_hash = calculate_hash(&readable_map);
 
     {
         println!("`challenge` file contains decompressed points and has a hash:");
@@ -213,7 +214,7 @@ fn main() {
     let output_readonly = writable_map
         .make_read_only()
         .expect("must make a map readonly");
-    let contribution_hash = BatchedAccumulator::<Bn256>::calculate_hash(&output_readonly);
+    let contribution_hash = calculate_hash(&output_readonly);
 
     print!(
         "Done!\n\n\

--- a/powersoftau/src/bin/compute_constrained.rs
+++ b/powersoftau/src/bin/compute_constrained.rs
@@ -1,7 +1,7 @@
 use powersoftau::{
     batched_accumulator::BatchedAccumulator,
     keypair::keypair,
-    parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
+    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
     utils::calculate_hash,
 };
 
@@ -26,7 +26,7 @@ fn main() {
     let circuit_power = args[3].parse().expect("could not parse circuit power");
     let batch_size = args[4].parse().expect("could not parse batch size");
 
-    let parameters = CeremonyParams::new(CurveKind::Bn256, circuit_power, batch_size);
+    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
 
     println!(
         "Will contribute to accumulator for 2^{} powers of tau",
@@ -190,7 +190,7 @@ fn main() {
     println!("Computing and writing your contribution, this could take a while...");
 
     // this computes a transformation and writes it
-    BatchedAccumulator::<Bn256>::transform(
+    BatchedAccumulator::transform(
         &readable_map,
         &mut writable_map,
         INPUT_IS_COMPRESSED,

--- a/powersoftau/src/bin/new_constrained.rs
+++ b/powersoftau/src/bin/new_constrained.rs
@@ -1,6 +1,6 @@
 use powersoftau::batched_accumulator::BatchedAccumulator;
 use powersoftau::parameters::UseCompression;
-use powersoftau::utils::blank_hash;
+use powersoftau::utils::{blank_hash, calculate_hash};
 
 use bellman_ce::pairing::bn256::Bn256;
 use memmap::*;
@@ -88,7 +88,7 @@ fn main() {
     let output_readonly = writable_map
         .make_read_only()
         .expect("must make a map readonly");
-    let contribution_hash = BatchedAccumulator::<Bn256>::calculate_hash(&output_readonly);
+    let contribution_hash = calculate_hash(&output_readonly);
 
     println!("Empty contribution is formed with a hash:");
 

--- a/powersoftau/src/bin/new_constrained.rs
+++ b/powersoftau/src/bin/new_constrained.rs
@@ -7,7 +7,7 @@ use memmap::*;
 use std::fs::OpenOptions;
 use std::io::Write;
 
-use powersoftau::parameters::{CeremonyParams, CurveKind};
+use powersoftau::parameters::CeremonyParams;
 
 const COMPRESS_NEW_CHALLENGE: UseCompression = UseCompression::No;
 
@@ -21,7 +21,7 @@ fn main() {
     let circuit_power = args[2].parse().expect("could not parse circuit power");
     let batch_size = args[3].parse().expect("could not parse batch size");
 
-    let parameters = CeremonyParams::new(CurveKind::Bn256, circuit_power, batch_size);
+    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
 
     println!(
         "Will generate an empty accumulator for 2^{} powers of tau",
@@ -74,12 +74,8 @@ fn main() {
         println!();
     }
 
-    BatchedAccumulator::<Bn256>::generate_initial(
-        &mut writable_map,
-        COMPRESS_NEW_CHALLENGE,
-        &parameters,
-    )
-    .expect("generation of initial accumulator is successful");
+    BatchedAccumulator::generate_initial(&mut writable_map, COMPRESS_NEW_CHALLENGE, &parameters)
+        .expect("generation of initial accumulator is successful");
     writable_map
         .flush()
         .expect("unable to flush memmap to disk");

--- a/powersoftau/src/bin/prepare_phase2.rs
+++ b/powersoftau/src/bin/prepare_phase2.rs
@@ -2,7 +2,7 @@ use bellman_ce::pairing::bn256::Bn256;
 use bellman_ce::pairing::bn256::{G1, G2};
 use bellman_ce::pairing::{CurveAffine, CurveProjective};
 use powersoftau::batched_accumulator::*;
-use powersoftau::parameters::{CeremonyParams, CurveKind};
+use powersoftau::parameters::CeremonyParams;
 use powersoftau::*;
 
 use crate::parameters::*;
@@ -25,8 +25,7 @@ fn log_2(x: u64) -> u32 {
 }
 
 fn main() {
-    let parameters = CeremonyParams::new(
-        CurveKind::Bn256,
+    let parameters = CeremonyParams::<Bn256>::new(
         28, // turn this to 10 for the small test
         21, // turn this to 8  for the small test
     );
@@ -49,7 +48,7 @@ fn main() {
             .expect("unable to create a memory map for input")
     };
 
-    let current_accumulator = BatchedAccumulator::<Bn256>::deserialize(
+    let current_accumulator = BatchedAccumulator::deserialize(
         &response_readable_map,
         CheckForCorrectness::Yes,
         UseCompression::Yes,

--- a/powersoftau/src/bin/prepare_phase2.rs
+++ b/powersoftau/src/bin/prepare_phase2.rs
@@ -25,17 +25,16 @@ fn log_2(x: u64) -> u32 {
 }
 
 fn main() {
-    let parameters = CeremonyParams::<Bn256>::new(
-        28, // turn this to 10 for the small test
-        21, // turn this to 8  for the small test
-    );
-
     let args: Vec<String> = std::env::args().collect();
-    if args.len() != 2 {
-        println!("Usage: \n<response_filename>");
+    if args.len() != 4 {
+        println!("Usage: \n<response_filename> <circuit_power> <batch_size>");
         std::process::exit(exitcode::USAGE);
     }
     let response_filename = &args[1];
+    let circuit_power = args[2].parse().expect("could not parse circuit power");
+    let batch_size = args[3].parse().expect("could not parse batch size");
+
+    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
 
     // Try to load response file from disk.
     let reader = OpenOptions::new()

--- a/powersoftau/src/bin/reduce_powers.rs
+++ b/powersoftau/src/bin/reduce_powers.rs
@@ -1,7 +1,7 @@
 use bellman_ce::pairing::bn256::Bn256;
 use powersoftau::{
     batched_accumulator::BatchedAccumulator,
-    parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
+    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
     utils::{calculate_hash, reduced_hash},
 };
 
@@ -20,8 +20,7 @@ pub fn log_2(x: u64) -> u32 {
 }
 
 fn main() {
-    let parameters = CeremonyParams::new(
-        CurveKind::Bn256,
+    let parameters = CeremonyParams::<Bn256>::new(
         10, // here we use 10 since it's the reduced ceremony
         21,
     );
@@ -37,7 +36,7 @@ fn main() {
             .expect("unable to create a memory map for input")
     };
 
-    let current_accumulator = BatchedAccumulator::<Bn256>::deserialize(
+    let current_accumulator = BatchedAccumulator::deserialize(
         &challenge_readable_map,
         CheckForCorrectness::Yes,
         UseCompression::No,
@@ -45,7 +44,7 @@ fn main() {
     )
     .expect("unable to read compressed accumulator");
 
-    let mut reduced_accumulator = BatchedAccumulator::<Bn256>::empty(&parameters);
+    let mut reduced_accumulator = BatchedAccumulator::empty(&parameters);
     reduced_accumulator.tau_powers_g1 =
         current_accumulator.tau_powers_g1[..parameters.powers_g1_length].to_vec();
     reduced_accumulator.tau_powers_g2 =

--- a/powersoftau/src/bin/reduce_powers.rs
+++ b/powersoftau/src/bin/reduce_powers.rs
@@ -2,7 +2,7 @@ use bellman_ce::pairing::bn256::Bn256;
 use powersoftau::{
     batched_accumulator::BatchedAccumulator,
     parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
-    utils::reduced_hash,
+    utils::{calculate_hash, reduced_hash},
 };
 
 use std::fs::OpenOptions;
@@ -105,7 +105,7 @@ fn main() {
     let output_readonly = writable_map
         .make_read_only()
         .expect("must make a map readonly");
-    let contribution_hash = BatchedAccumulator::<Bn256>::calculate_hash(&output_readonly);
+    let contribution_hash = calculate_hash(&output_readonly);
 
     println!("Reduced contribution is formed with a hash:");
 

--- a/powersoftau/src/bin/verify.rs
+++ b/powersoftau/src/bin/verify.rs
@@ -2,8 +2,8 @@ use bellman_ce::pairing::bn256::Bn256;
 use bellman_ce::pairing::bn256::{G1, G2};
 use bellman_ce::pairing::{CurveAffine, CurveProjective};
 use powersoftau::batched_accumulator::*;
-use powersoftau::*;
 use powersoftau::parameters::{CeremonyParams, CurveKind};
+use powersoftau::*;
 
 use crate::keypair::*;
 use crate::parameters::*;

--- a/powersoftau/src/bin/verify.rs
+++ b/powersoftau/src/bin/verify.rs
@@ -2,7 +2,7 @@ use bellman_ce::pairing::bn256::Bn256;
 use bellman_ce::pairing::bn256::{G1, G2};
 use bellman_ce::pairing::{CurveAffine, CurveProjective};
 use powersoftau::batched_accumulator::*;
-use powersoftau::parameters::{CeremonyParams, CurveKind};
+use powersoftau::parameters::CeremonyParams;
 use powersoftau::*;
 
 use crate::keypair::*;
@@ -71,14 +71,14 @@ impl<W: Write> Write for HashWriter<W> {
 // Computes the hash of the challenge file for the player,
 // given the current state of the accumulator and the last
 // response file hash.
-fn get_challenge_file_hash(
-    acc: &mut BatchedAccumulator<Bn256>,
+fn get_challenge_file_hash<E: Engine>(
+    acc: &mut BatchedAccumulator<E>,
     last_response_file_hash: &[u8; 64],
     is_initial: bool,
-    parameters: &CeremonyParams,
 ) -> [u8; 64] {
     let sink = io::sink();
     let mut sink = HashWriter::new(sink);
+    let parameters = acc.parameters;
 
     let file_name = "tmp_challenge_file_hash";
 
@@ -110,12 +110,8 @@ fn get_challenge_file_hash(
             .expect("unable to write blank hash to challenge file");
 
         if is_initial {
-            BatchedAccumulator::<Bn256>::generate_initial(
-                &mut writable_map,
-                UseCompression::No,
-                parameters,
-            )
-            .expect("generation of initial accumulator is successful");
+            BatchedAccumulator::generate_initial(&mut writable_map, UseCompression::No, parameters)
+                .expect("generation of initial accumulator is successful");
         } else {
             acc.serialize(&mut writable_map, UseCompression::No, parameters)
                 .unwrap();
@@ -140,17 +136,19 @@ fn get_challenge_file_hash(
     tmp
 }
 
+use bellman_ce::pairing::Engine;
+
 // Computes the hash of the response file, given the new
 // accumulator, the player's public key, and the challenge
 // file's hash.
-fn get_response_file_hash(
-    acc: &mut BatchedAccumulator<Bn256>,
-    pubkey: &PublicKey<Bn256>,
+fn get_response_file_hash<E: Engine>(
+    acc: &mut BatchedAccumulator<E>,
+    pubkey: &PublicKey<E>,
     last_challenge_file_hash: &[u8; 64],
-    parameters: &CeremonyParams,
 ) -> [u8; 64] {
     let sink = io::sink();
     let mut sink = HashWriter::new(sink);
+    let parameters = acc.parameters;
 
     let file_name = "tmp_response_file_hash";
     if Path::new(file_name).exists() {
@@ -205,7 +203,7 @@ fn get_response_file_hash(
     tmp
 }
 
-fn new_accumulator_for_verify(parameters: &CeremonyParams) -> BatchedAccumulator<Bn256> {
+fn new_accumulator_for_verify(parameters: &CeremonyParams<Bn256>) -> BatchedAccumulator<Bn256> {
     let file_name = "tmp_initial_challenge";
     {
         if Path::new(file_name).exists() {
@@ -228,12 +226,8 @@ fn new_accumulator_for_verify(parameters: &CeremonyParams) -> BatchedAccumulator
                 .map_mut(&file)
                 .expect("unable to create a memory map")
         };
-        BatchedAccumulator::<Bn256>::generate_initial(
-            &mut writable_map,
-            UseCompression::No,
-            &parameters,
-        )
-        .expect("generation of initial accumulator is successful");
+        BatchedAccumulator::generate_initial(&mut writable_map, UseCompression::No, &parameters)
+            .expect("generation of initial accumulator is successful");
         writable_map
             .flush()
             .expect("unable to flush memmap to disk");
@@ -269,7 +263,7 @@ fn main() {
     let circuit_power = args[2].parse().expect("could not parse circuit power");
     let batch_size = args[3].parse().expect("could not parse batch size");
 
-    let parameters = CeremonyParams::new(CurveKind::Bn256, circuit_power, batch_size);
+    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
 
     // Try to load transcript file from disk.
     let reader = OpenOptions::new()
@@ -329,12 +323,8 @@ fn main() {
             .make_read_only()
             .expect("must make a map readonly");
 
-        let last_challenge_file_hash = get_challenge_file_hash(
-            &mut current_accumulator,
-            &last_response_file_hash,
-            i == 0,
-            &parameters,
-        );
+        let last_challenge_file_hash =
+            get_challenge_file_hash(&mut current_accumulator, &last_response_file_hash, i == 0);
 
         // Deserialize the accumulator provided by the player in
         // their response file. It's stored in the transcript in
@@ -350,8 +340,7 @@ fn main() {
         .expect("unable to read uncompressed accumulator");
 
         let response_file_pubkey =
-            PublicKey::<Bn256>::read(&response_readable_map, UseCompression::Yes, &parameters)
-                .unwrap();
+            PublicKey::read(&response_readable_map, UseCompression::Yes, &parameters).unwrap();
         // Compute the hash of the response file. (we had it in uncompressed
         // form in the transcript, but the response file is compressed to save
         // participants bandwidth.)
@@ -359,7 +348,6 @@ fn main() {
             &mut response_file_accumulator,
             &response_file_pubkey,
             &last_challenge_file_hash,
-            &parameters,
         );
 
         // Verify the transformation from the previous accumulator to the new

--- a/powersoftau/src/bin/verify_transform_constrained.rs
+++ b/powersoftau/src/bin/verify_transform_constrained.rs
@@ -1,14 +1,15 @@
-use powersoftau::batched_accumulator::BatchedAccumulator;
-use powersoftau::keypair::PublicKey;
-use powersoftau::parameters::{CheckForCorrectness, UseCompression};
+use powersoftau::{
+    batched_accumulator::BatchedAccumulator,
+    keypair::PublicKey,
+    parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
+    utils::calculate_hash,
+};
 
 use bellman_ce::pairing::bn256::Bn256;
 use memmap::*;
 use std::fs::OpenOptions;
 
 use std::io::{Read, Write};
-
-use powersoftau::parameters::{CeremonyParams, CurveKind};
 
 const PREVIOUS_CHALLENGE_IS_COMPRESSED: UseCompression = UseCompression::No;
 const CONTRIBUTION_IS_COMPRESSED: UseCompression = UseCompression::Yes;
@@ -95,8 +96,7 @@ fn main() {
 
     // Check that contribution is correct
 
-    let current_accumulator_hash =
-        BatchedAccumulator::<Bn256>::calculate_hash(&challenge_readable_map);
+    let current_accumulator_hash = calculate_hash(&challenge_readable_map);
 
     println!("Hash of the `challenge` file for verification:");
     for line in current_accumulator_hash.as_slice().chunks(16) {
@@ -137,7 +137,7 @@ fn main() {
         }
     }
 
-    let response_hash = BatchedAccumulator::<Bn256>::calculate_hash(&response_readable_map);
+    let response_hash = calculate_hash(&response_readable_map);
 
     println!("Hash of the response file for verification:");
     for line in response_hash.as_slice().chunks(16) {
@@ -234,8 +234,7 @@ fn main() {
             .make_read_only()
             .expect("must make a map readonly");
 
-        let recompressed_hash =
-            BatchedAccumulator::<Bn256>::calculate_hash(&new_challenge_readable_map);
+        let recompressed_hash = calculate_hash(&new_challenge_readable_map);
 
         println!("Here's the BLAKE2b hash of the decompressed participant's response as new_challenge file:");
 

--- a/powersoftau/src/bin/verify_transform_constrained.rs
+++ b/powersoftau/src/bin/verify_transform_constrained.rs
@@ -1,7 +1,7 @@
 use powersoftau::{
     batched_accumulator::BatchedAccumulator,
     keypair::PublicKey,
-    parameters::{CeremonyParams, CheckForCorrectness, CurveKind, UseCompression},
+    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
     utils::calculate_hash,
 };
 
@@ -27,7 +27,7 @@ fn main() {
     let circuit_power = args[4].parse().expect("could not parse circuit power");
     let batch_size = args[5].parse().expect("could not parse batch size");
 
-    let parameters = CeremonyParams::new(CurveKind::Bn256, circuit_power, batch_size);
+    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
 
     println!(
         "Will verify and decompress a contribution to accumulator for 2^{} powers of tau",
@@ -152,7 +152,7 @@ fn main() {
     }
 
     // get the contributor's public key
-    let public_key = PublicKey::<Bn256>::read(
+    let public_key = PublicKey::read(
         &response_readable_map,
         CONTRIBUTION_IS_COMPRESSED,
         &parameters,
@@ -165,7 +165,7 @@ fn main() {
         "Verifying a contribution to contain proper powers and correspond to the public key..."
     );
 
-    let valid = BatchedAccumulator::<Bn256>::verify_transformation(
+    let valid = BatchedAccumulator::verify_transformation(
         &challenge_readable_map,
         &response_readable_map,
         &public_key,
@@ -220,7 +220,7 @@ fn main() {
                 .expect("unable to write hash to new challenge file");
         }
 
-        BatchedAccumulator::<Bn256>::decompress(
+        BatchedAccumulator::decompress(
             &response_readable_map,
             &mut writable_map,
             CheckForCorrectness::No,

--- a/powersoftau/src/keypair.rs
+++ b/powersoftau/src/keypair.rs
@@ -171,7 +171,7 @@ impl<E: Engine> PublicKey<E> {
         &self,
         output_map: &mut MmapMut,
         accumulator_was_compressed: UseCompression,
-        parameters: &CeremonyParams,
+        parameters: &CeremonyParams<E>,
     ) -> io::Result<()> {
         let mut position = match accumulator_was_compressed {
             UseCompression::Yes => parameters.contribution_size - parameters.public_key_size,
@@ -218,7 +218,7 @@ impl<E: Engine> PublicKey<E> {
     pub fn read(
         input_map: &Mmap,
         accumulator_was_compressed: UseCompression,
-        parameters: &CeremonyParams,
+        parameters: &CeremonyParams<E>,
     ) -> Result<Self, DeserializationError> {
         fn read_uncompressed<EE: Engine, C: CurveAffine<Engine = EE, Scalar = EE::Fr>>(
             input_map: &Mmap,
@@ -291,12 +291,12 @@ mod tests {
 
     mod bn256 {
         use super::*;
-        use crate::parameters::{CurveKind, CurveParams};
+        use crate::parameters::CurveParams;
         use bellman_ce::pairing::bn256::Bn256;
 
         #[test]
         fn test_pubkey_serialization() {
-            let curve = CurveParams::new(CurveKind::Bn256);
+            let curve = CurveParams::<Bn256>::new();
             let public_key_size = 6 * curve.g1 + 3 * curve.g2;
 
             // Generate a random public key


### PR DESCRIPTION
This PR moves any type specialization required to the `CeremonyParams` object, allowing us to configure it once with the setup size, and curve type. The accumulator and keypair objects then will use the parameters to figure out which curve they're on.