### PR TITLE
CLI Refactor

### DIFF
--- a/powersoftau/Cargo.lock
+++ b/powersoftau/Cargo.lock
@@ -210,6 +210,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gumdrop"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gumdrop_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +343,7 @@ dependencies = [
  "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -357,11 +376,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -449,6 +484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +511,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -513,6 +563,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
+"checksum gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee50908bc1beeac1f2902e0b4e0cd0d844e716f5ebdc6f0cfc1163fe5e10bcde"
+"checksum gumdrop_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc2928beef125e519d69ae1baa8c37ea2e0d3848545217f6db0179c5eb1d639"
 "checksum hex-literal-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d340b6514f232f6db1bd16db65302a5278a04fef9ce867cb932e7e5fa21130a"
@@ -530,7 +582,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro-hack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c725b36c99df7af7bf9324e9c999b9e37d92c8f8caf106d82e1d7953218d2d8"
 "checksum proc-macro-hack-impl 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2b753ad9ed99dd8efeaa7d2fb8453c8f6bc3e54b97966d35f1bc77ca6865254a"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
@@ -542,9 +596,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
+"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -27,3 +27,4 @@ itertools = "0.8.0"
 
 bellman_ce = { path = "../bellman" }
 log = "0.4.8"
+gumdrop = "0.7.0"

--- a/powersoftau/src/cli_common/mod.rs
+++ b/powersoftau/src/cli_common/mod.rs
@@ -109,7 +109,7 @@ pub struct VerifyOpts {
     pub transcript_fname: String,
 }
 
-fn curve_from_str(src: &str) -> Result<CurveKind, String> {
+pub fn curve_from_str(src: &str) -> Result<CurveKind, String> {
     let curve = match src.to_lowercase().as_str() {
         "bn256" => CurveKind::Bn256,
         _ => return Err("unsupported curve. Currently supported: bn256".to_string()),
@@ -117,7 +117,7 @@ fn curve_from_str(src: &str) -> Result<CurveKind, String> {
     Ok(curve)
 }
 
-fn proving_system_from_str(src: &str) -> Result<ProvingSystem, String> {
+pub fn proving_system_from_str(src: &str) -> Result<ProvingSystem, String> {
     let system = match src.to_lowercase().as_str() {
         "groth16" => ProvingSystem::Groth16,
         _ => return Err("unsupported proving system. Currently supported: groth16".to_string()),

--- a/powersoftau/src/cli_common/mod.rs
+++ b/powersoftau/src/cli_common/mod.rs
@@ -1,0 +1,126 @@
+mod new_constrained;
+pub use new_constrained::new_constrained;
+
+mod compute_constrained;
+pub use compute_constrained::compute_constrained;
+
+mod transform;
+pub use transform::transform;
+
+mod beacon;
+pub use beacon::beacon;
+
+mod verify;
+pub use verify::verify;
+
+use gumdrop::Options;
+use std::default::Default;
+
+#[derive(Debug, Clone)]
+pub enum CurveKind {
+    Bn256,
+}
+
+#[derive(Debug, Clone)]
+pub enum ProvingSystem {
+    Groth16,
+}
+
+#[derive(Debug, Options, Clone)]
+pub struct PowersOfTauOpts {
+    help: bool,
+    #[options(
+        help = "the elliptic curve to use",
+        default = "bn256",
+        parse(try_from_str = "curve_from_str")
+    )]
+    pub curve_kind: CurveKind,
+    #[options(
+        help = "the proving system to use",
+        default = "groth16",
+        parse(try_from_str = "proving_system_from_str")
+    )]
+    pub proving_system: ProvingSystem,
+    #[options(help = "the size of batches to process", default = "256")]
+    pub batch_size: usize,
+    #[options(
+        help = "the circuit power (circuit size will be 2^{power})",
+        default = "21"
+    )]
+    pub power: usize,
+    #[options(command)]
+    pub command: Option<Command>,
+}
+
+// The supported commands
+#[derive(Debug, Options, Clone)]
+pub enum Command {
+    // this checks if a challenge file is already present and if not it creates it
+    // equivalent of `new_constrained` + `compute_constrained`. Generates a response
+    #[options(
+        help = "contribute to ceremony by producing a response to a challenge (or create a new challenge if this is the first contribution)"
+    )]
+    Contribute(ContributeOpts),
+    #[options(
+        help = "contribute randomness via a random beacon (e.g. a bitcoin block header hash)"
+    )]
+    Beacon(ContributeOpts),
+    // this receives a challenge + response file, verifies it and generates a new challenge
+    #[options(help = "verify the contributions so far and generate a new challenge")]
+    Transform(TransformOpts),
+    #[options(help = "verify that the transcript was generated correctly")]
+    Verify(VerifyOpts),
+}
+
+// Options for the Contribute command
+#[derive(Debug, Options, Clone)]
+pub struct ContributeOpts {
+    help: bool,
+    #[options(
+        help = "the provided challenge file (will create a new one if you are the first participant in the ceremony",
+        default = "challenge"
+    )]
+    pub challenge_fname: String,
+    #[options(help = "the response file which will be generated")]
+    pub response_fname: String,
+}
+
+#[derive(Debug, Options, Clone)]
+pub struct TransformOpts {
+    help: bool,
+    #[options(help = "the provided challenge file", default = "challenge")]
+    pub challenge_fname: String,
+    #[options(
+        help = "the provided response file which will be verified",
+        default = "response"
+    )]
+    pub response_fname: String,
+    #[options(
+        help = "the new challenge file which will be generated in response",
+        default = "new_challenge"
+    )]
+    pub new_challenge_fname: String,
+}
+
+#[derive(Debug, Options, Clone)]
+pub struct VerifyOpts {
+    help: bool,
+    #[options(help = "the ceremony's transcript", default = "transcript")]
+    pub transcript_fname: String,
+}
+
+fn curve_from_str(src: &str) -> Result<CurveKind, String> {
+    let curve = match src.to_lowercase().as_str() {
+        "bn256" => CurveKind::Bn256,
+        _ => return Err("unsupported curve. Currently supported: bn256".to_string()),
+    };
+    Ok(curve)
+}
+
+fn proving_system_from_str(src: &str) -> Result<ProvingSystem, String> {
+    let system = match src.to_lowercase().as_str() {
+        "groth16" => ProvingSystem::Groth16,
+        _ => return Err("unsupported proving system. Currently supported: groth16".to_string()),
+    };
+    Ok(system)
+}

--- a/powersoftau/src/cli_common/new_constrained.rs
+++ b/powersoftau/src/cli_common/new_constrained.rs
@@ -1,28 +1,15 @@
-use powersoftau::batched_accumulator::BatchedAccumulator;
-use powersoftau::parameters::UseCompression;
-use powersoftau::utils::{blank_hash, calculate_hash};
+use crate::batched_accumulator::BatchedAccumulator;
+use crate::parameters::{CeremonyParams, UseCompression};
+use crate::utils::{blank_hash, calculate_hash};
 
-use bellman_ce::pairing::bn256::Bn256;
+use bellman_ce::pairing::Engine;
 use memmap::*;
 use std::fs::OpenOptions;
 use std::io::Write;
 
-use powersoftau::parameters::CeremonyParams;
-
 const COMPRESS_NEW_CHALLENGE: UseCompression = UseCompression::No;
 
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() != 4 {
-        println!("Usage: \n<challenge_file> <ceremony_size> <batch_size>");
-        std::process::exit(exitcode::USAGE);
-    }
-    let challenge_filename = &args[1];
-    let circuit_power = args[2].parse().expect("could not parse circuit power");
-    let batch_size = args[3].parse().expect("could not parse batch size");
-
-    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
-
+pub fn new_constrained<T: Engine>(challenge_filename: &str, parameters: &CeremonyParams<T>) {
     println!(
         "Will generate an empty accumulator for 2^{} powers of tau",
         parameters.size

--- a/powersoftau/src/cli_common/transform.rs
+++ b/powersoftau/src/cli_common/transform.rs
@@ -1,11 +1,10 @@
-use powersoftau::{
+use crate::{
     batched_accumulator::BatchedAccumulator,
     keypair::PublicKey,
     parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
     utils::calculate_hash,
 };
-
-use bellman_ce::pairing::bn256::Bn256;
+use bellman_ce::pairing::Engine;
 use memmap::*;
 use std::fs::OpenOptions;
 
@@ -15,20 +14,12 @@ const PREVIOUS_CHALLENGE_IS_COMPRESSED: UseCompression = UseCompression::No;
 const CONTRIBUTION_IS_COMPRESSED: UseCompression = UseCompression::Yes;
 const COMPRESS_NEW_CHALLENGE: UseCompression = UseCompression::No;
 
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() != 6 {
-        println!("Usage: \n<challenge_file> <response_file> <new_challenge_file> <circuit_power> <batch_size>");
-        std::process::exit(exitcode::USAGE);
-    }
-    let challenge_filename = &args[1];
-    let response_filename = &args[2];
-    let new_challenge_filename = &args[3];
-    let circuit_power = args[4].parse().expect("could not parse circuit power");
-    let batch_size = args[5].parse().expect("could not parse batch size");
-
-    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
-
+pub fn transform<T: Engine>(
+    challenge_filename: &str,
+    response_filename: &str,
+    new_challenge_filename: &str,
+    parameters: &CeremonyParams<T>,
+) {
     println!(
         "Will verify and decompress a contribution to accumulator for 2^{} powers of tau",
         parameters.size

--- a/powersoftau/src/lib.rs
+++ b/powersoftau/src/lib.rs
@@ -4,4 +4,4 @@ pub mod parameters;
 pub mod utils;
 
 #[allow(dead_code)]
-mod cli_common;
+pub mod cli_common;

--- a/powersoftau/src/lib.rs
+++ b/powersoftau/src/lib.rs
@@ -2,3 +2,6 @@ pub mod batched_accumulator;
 pub mod keypair;
 pub mod parameters;
 pub mod utils;
+
+#[allow(dead_code)]
+mod cli_common;

--- a/powersoftau/src/main.rs
+++ b/powersoftau/src/main.rs
@@ -1,0 +1,69 @@
+pub mod batched_accumulator;
+mod cli_common;
+pub mod keypair;
+pub mod parameters;
+pub mod utils;
+
+use cli_common::{
+    beacon, compute_constrained, new_constrained, transform, verify, Command, PowersOfTauOpts,
+};
+use gumdrop::Options;
+
+use crate::parameters::CeremonyParams;
+use bellman_ce::pairing::bn256::Bn256;
+use std::path::PathBuf;
+use std::process;
+
+#[macro_use]
+extern crate hex_literal;
+
+fn main() {
+    let opts: PowersOfTauOpts = PowersOfTauOpts::parse_args_default_or_exit();
+
+    // TODO: Make this depend on `opts.curve_kind`
+    let parameters = CeremonyParams::<Bn256>::new(opts.power, opts.batch_size);
+
+    let command = opts.command.unwrap_or_else(|| {
+        eprintln!("No command was provided.");
+        eprintln!("{}", PowersOfTauOpts::usage());
+        process::exit(2)
+    });
+
+    match command {
+        Command::Contribute(opt) => {
+            let challenge_fname = opt.challenge_fname;
+            let challenge_file = PathBuf::from(&challenge_fname);
+
+            if !challenge_file.exists() {
+                // If the challenge file does not exist, then we have to first initiate the ceremony
+                new_constrained(&challenge_fname, &parameters);
+            }
+            // contribute to the randomness
+            compute_constrained(&challenge_fname, &opt.response_fname, &parameters)
+        }
+        Command::Beacon(opt) => {
+            // use the beacon's randomness
+            // Place block hash here (block number #564321)
+            let beacon_hash: [u8; 32] =
+                hex!("0000000000000000000a558a61ddc8ee4e488d647a747fe4dcc362fe2026c620");
+            beacon(
+                &opt.challenge_fname,
+                &opt.response_fname,
+                &parameters,
+                beacon_hash,
+            );
+        }
+        Command::Transform(opt) => {
+            // we receive a previous participation, verify it, and generate a new challenge from it
+            transform(
+                &opt.challenge_fname,
+                &opt.response_fname,
+                &opt.new_challenge_fname,
+                &parameters,
+            );
+        }
+        Command::Verify(opt) => {
+            verify(&opt.transcript_fname, &parameters);
+        }
+    };
+}

--- a/powersoftau/test.sh
+++ b/powersoftau/test.sh
@@ -11,18 +11,19 @@ set -e
 SIZE=10
 BATCH=256
 
-cargo run --release --bin new_constrained challenge1 $SIZE $BATCH
-yes | cargo run --release --bin compute_constrained challenge1 response1 $SIZE $BATCH
-cargo run --release --bin verify_transform_constrained challenge1 response1 challenge2 $SIZE $BATCH
+# since the `challenge1` file does not exist, this will also create it
+yes | cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE contribute --challenge-fname challenge1 --response-fname response1
+cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE transform --challenge-fname challenge1 --response-fname response1 --new-challenge-fname challenge2
 
-yes | cargo run --release --bin compute_constrained challenge2 response2 $SIZE $BATCH
-cargo run --release --bin verify_transform_constrained challenge2 response2 challenge3 $SIZE $BATCH
+yes | cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE contribute --challenge-fname challenge2 --response-fname response2
+cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE transform --challenge-fname challenge2 --response-fname response2 --new-challenge-fname challenge3
 
-yes | cargo run --release --bin compute_constrained challenge3 response3 $SIZE $BATCH
-cargo run --release --bin verify_transform_constrained challenge3 response3 challenge4 $SIZE $BATCH
+yes | cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE contribute --challenge-fname challenge3 --response-fname response3
+cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE transform --challenge-fname challenge3 --response-fname response3 --new-challenge-fname challenge4
 
-cargo run --release --bin beacon_constrained challenge4 response4 $SIZE $BATCH
-cargo run --release --bin verify_transform_constrained challenge4 response4 challenge5 $SIZE $BATCH
+# add a randomness contribution by a beacon at the end
+cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE beacon --challenge-fname challenge4 --response-fname response4
+cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE transform --challenge-fname challenge4 --response-fname response4 --new-challenge-fname challenge5
 
 cat response1 response2 response3 response4 > transcript
-cargo run --release --bin verify  transcript $SIZE $BATCH
+cargo run --release --bin powersoftau -- --batch-size $BATCH --power $SIZE verify --transcript-fname transcript


### PR DESCRIPTION
This combines the multiple binaries used for the ceremony in 1, with intuitive command line flags used for specifying the individual params. We default to using a circuit size of 2^21, batches of 256, groth16 and bn256.

Example output:
```bash
Usage: ./target/debug/powersoftau [OPTIONS]

Optional arguments:
  -h, --help
  -c, --curve-kind CURVE-KIND
                     the elliptic curve to use (default: bn256)
  -p, --proving-system PROVING-SYSTEM
                     the proving system to use (default: groth16)
  -b, --batch-size BATCH-SIZE
                     the size of batches to process (default: 256)
  -P, --power POWER  the circuit power (circuit size will be 2^{power}) (default: 21)

Available commands:

  contribute  contribute to ceremony by producing a response to a challenge (or create a new challenge if this is the first contribution)
  beacon      contribute randomness via a random beacon (e.g. a bitcoin block header hash)
  transform   verify the contributions so far and generate a new challenge
  verify      verify that the transcript was generated correctly**
```

The `reduce_powers` and `prepare_phase2` binaries are kept separate as before since they serve different purposes.