### PR TITLE
Change multiplicative generator of bn254 to 5 instead of 7

### DIFF
--- a/pairing/src/bn256/fr.rs
+++ b/pairing/src/bn256/fr.rs
@@ -2,7 +2,7 @@ use ff::{Field, PrimeField, PrimeFieldRepr};
 
 #[derive(PrimeField)]
 #[PrimeFieldModulus = "21888242871839275222246405745257275088548364400416034343698204186575808495617"]
-#[PrimeFieldGenerator = "7"]
+#[PrimeFieldGenerator = "5"]
 pub struct Fr(FrRepr);
 
 #[test]


### PR DESCRIPTION
In the field Fr of the curve bn254 the lowest generator is 5 instead of 7. 

This is the standard used in other libraries. 

See:

* https://github.com/scipr-lab/libff/blob/176f3f42fdef791f12b24417a400c4b6d386863c/libff/algebra/curves/alt_bn128/alt_bn128_init.cpp#L59
* https://github.com/scipr-lab/libff/blob/176f3f42fdef791f12b24417a400c4b6d386863c/libff/algebra/curves/bn128/bn128_init.cpp#L57


This PR breaks backwards compatibility, but I believe it's important to fix it ASAP so we use 5 for the new circuits.