### PR TITLE
A utility to print the powers of tau from a challenge file

### DIFF
--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -272,6 +272,43 @@ pub fn verify_transform<E: Engine>(
 }
 
 impl<'a, E: Engine> BatchedAccumulator<'a, E> {
+    #[allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
+    pub fn print_powers(
+        input_map: &Mmap,
+        input_is_compressed: UseCompression,
+        check_input_for_correctness: CheckForCorrectness,
+        parameters: &'a CeremonyParams<E>,
+        element_type: ElementType,
+        num_to_extract: usize,
+    ) {
+        let mut acc = Self::empty(parameters);
+
+        for i in 0..num_to_extract {
+            let chunk_size = 1;
+            acc.read_chunk(
+                i,
+                chunk_size,
+                input_is_compressed,
+                check_input_for_correctness,
+                &input_map,
+            ).expect("must read a first chunk from `challenge`");
+
+            let tau_g1 = acc.tau_powers_g1[0];
+            let tau_g2 = acc.tau_powers_g2[0];
+            let alpha_g1 = acc.alpha_tau_powers_g1[0];
+            let beta_g1 = acc.beta_tau_powers_g1[0];
+            let beta_g2 = acc.beta_g2;
+
+            match element_type {
+                ElementType::TauG1 => println!("{}", tau_g1),
+                ElementType::TauG2 => println!("{}", tau_g2),
+                ElementType::AlphaG1 => println!("{}", alpha_g1),
+                ElementType::BetaG1 => println!("{}", beta_g1),
+                ElementType::BetaG2 => println!("{}", beta_g2),
+            }
+        }
+    }
+
     /// Verifies a transformation of the `Accumulator` with the `PublicKey`, given a 64-byte transcript `digest`.
     #[allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
     pub fn verify_transformation(

--- a/powersoftau/src/bin/print_powers.rs
+++ b/powersoftau/src/bin/print_powers.rs
@@ -1,0 +1,72 @@
+use powersoftau::{
+    batched_accumulator::BatchedAccumulator,
+    parameters::{CeremonyParams, CheckForCorrectness, UseCompression, ElementType},
+};
+
+use bellman_ce::pairing::bn256::Bn256;
+use memmap::*;
+use std::fs::OpenOptions;
+
+const PREVIOUS_CHALLENGE_IS_COMPRESSED: UseCompression = UseCompression::No;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 6 {
+        println!("Usage: \n<challenge_file> <circuit_power> <batch_size> <category_to_extract> <num_to_extract>");
+        std::process::exit(exitcode::USAGE);
+    }
+    let challenge_filename = &args[1];
+    let circuit_power = args[2].parse().expect("could not parse circuit power");
+    let batch_size = args[3].parse().expect("could not parse batch size");
+    let element_type_to_extract: String = args[4].parse().expect("could not parse the element type of the value to extract");
+    let num_to_extract = args[5].parse().expect("could not parse the number of values to extract");
+
+    let parameters = CeremonyParams::<Bn256>::new(circuit_power, batch_size);
+
+    // Try to load challenge file from disk.
+    let challenge_reader = OpenOptions::new()
+        .read(true)
+        .open(challenge_filename)
+        .expect("unable open challenge file in this directory");
+
+    {
+        let metadata = challenge_reader
+            .metadata()
+            .expect("unable to get filesystem metadata for challenge file");
+        let expected_challenge_length = match PREVIOUS_CHALLENGE_IS_COMPRESSED {
+            UseCompression::Yes => parameters.contribution_size - parameters.public_key_size,
+            UseCompression::No => parameters.accumulator_size,
+        };
+        if metadata.len() != (expected_challenge_length as u64) {
+            panic!(
+                "The size of challenge file should be {}, but it's {}, so something isn't right.",
+                expected_challenge_length,
+                metadata.len()
+            );
+        }
+    }
+
+    let challenge_readable_map = unsafe {
+        MmapOptions::new()
+            .map(&challenge_reader)
+            .expect("unable to create a memory map for input")
+    };
+
+    let et = match String::from(element_type_to_extract.to_lowercase()).as_ref() {
+        "taug1" => ElementType::TauG1,
+        "taug2" => ElementType::TauG2,
+        "alphag1" => ElementType::AlphaG1,
+        "betag1" => ElementType::BetaG1,
+        "betag2" => ElementType::BetaG2,
+        _ => ElementType::TauG1,
+    };
+
+    BatchedAccumulator::print_powers(
+        &challenge_readable_map,
+        PREVIOUS_CHALLENGE_IS_COMPRESSED,
+        CheckForCorrectness::No,
+        &parameters,
+        et,
+        num_to_extract
+    );
+}

--- a/powersoftau/test.sh
+++ b/powersoftau/test.sh
@@ -25,3 +25,6 @@ cargo run --release --bin beacon_constrained challenge4 response4 $SIZE $BATCH 0
 cargo run --release --bin verify_transform_constrained challenge4 response4 challenge5 $SIZE $BATCH
 
 cargo run --release --bin prepare_phase2 response4 $SIZE $BATCH
+
+echo "First two G1 powers of tau:"
+cargo run --release --bin print_powers challenge5 $SIZE $BATCH taug1 2


### PR DESCRIPTION
This PR introduces a `print_powers` program that reads a challenge file and outputs the powers of tau stored in it. It is useful for anyone who wants to use these values for purposes such as polynomial commitment libraries.

```
Usage: 
<challenge_file> <circuit_power> <batch_size> <category_to_extract> <num_to_extract>
```

`<category_to_extract>` should be one of:

- `taug1`
- `taug2`
- `alphag1`
- `betag1`
- `betag2`

For example, this command prints the first 2 TauG2 elements stored in `challenge`. Note that `challenge` was generated using a circuit power of 28 and batch size of 256:

```
phase2-bn254/powersoftau$ ./target/release/print_powers challenge 28 256 taug2 2
G2(x=Fq2(Fq(0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed) + Fq(0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2) * u), y=Fq2(Fq(0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa) + Fq(0x090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b) * u))
G2(x=Fq2(Fq(0x04c5e74c85a87f008a2feb4b5c8a1e7f9ba9d8eb40eb02e70139c89fb1c505a9) + Fq(0x21a808dad5c50720fb7294745cf4c87812ce0ea76baa7df4e922615d1388f25a) * u), y=Fq2(Fq(0x2d58022915fc6bc90e036e858fbc98055084ac7aff98ccceb0e3fde64bc1a084) + Fq(0x204b66d8e1fadc307c35187a6b813be0b46ba1cd720cd1c4ee5f68d13036b4ba) * u))
```

Note how in the above example, the first TauG2 element is the generator of the G_2 group [as specified in EIP-197](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-197.md).